### PR TITLE
Wip sophia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ datasets/
 results/
 secrets/
 output/
+visualizations/*/
 wandb/
 .vscode/
 todo

--- a/config_train.yaml
+++ b/config_train.yaml
@@ -5,8 +5,8 @@ general:
   app_name: "Pulse"
   version: "1.0.0"
   debug_mode: true
-  debug_data_length: 1000 # Number of rows used if debug_mode is true
-  debug_logging: true # false: logging level DEBUG, true: logging level INFO
+  debug_data_length: 500 # Number of rows used if debug_mode is true
+  debug_logging: true # true: logging level DEBUG, false: logging level INFO
   use_scratch: true
 
 # Weight and Biases (wandb) logging configuration
@@ -15,7 +15,7 @@ wandb:
   entity: "berner"
 
 ###### Application specific settings ######
-base_path: "" #"/cluster/project/bmds_lab/sepsis_sophia/pulse" # #"/path/to/pulse"
+base_path: "/Users/sophiaehlers/Documents/pulse"
 
 # Tasks to process
 tasks:
@@ -32,14 +32,10 @@ datasets:
 
 # _______ Preprocessing Baseline _______
 
-# Random seed for reproducibility
-random_seed: 42
-
-# Options for preprocessing
 preprocessing_baseline:
   replace_outliers: true # Whether to replace outliers with NaNs
   flag_na: true # Whether to flag NA values with binary indicators
-  standardize: false # Whether to standardize features (yes: convDL, not required: convML, LLM)
+  standardize: true # Whether to standardize features (yes: convDL, not required: convML, LLM)
   static_imputation: true # Whether to perform static feature imputation
   dynamic_imputation: true # Whether to perform dynamic feature imputation
   save_data: true # Whether to save preprocessed data
@@ -47,7 +43,8 @@ preprocessing_baseline:
     train: 0.8
     val: 0.1
     test: 0.1
-    test_limited: 50 # Number of stay_ids for limited test set, null = test set is not limited
+    test_limited: 100 # Number of stay_ids for limited test set, null = test set is not limited
+    print_stats: false # Whether to print set statistics
 
 # _______ Preprocessing Advanced _______
 
@@ -59,26 +56,30 @@ preprocessing_advanced:
     step_size: 1 # Step size for sliding windows
     save_data: true # Whether to save windowed data
 
+# _______ Preprocessing Prompting _______
+
 prompting:
   prompting_ids:
     # - "few_shot_paper_preprocessor" # Preprocessing ID for the model
-    # - "zhu_2024_is_larger_always_better_preprocessor"
-    - "sarvari_aggregation_preprocessor"
+    # - "zhu_2024a_one_shot_cot_preprocessor"
+    # - "zhu_2024b_one_shot_preprocessor"
+    # - "zhu_2024c_categorization_summary_preprocessor"
+    # - "sarvari_aggregation_preprocessor"
+    # - "agentic_prompt_test_preprocessor"
   shots: 3
-
-  # TODO: change shots from model config to here
 
 # _______ Model Training _______
 
 benchmark_settings:
-  batch_size: 100
+  batch_size: 64
+  random_seed: 42
 
 load_models:
-  - model_configs/Llama3.yaml
+  # - model_configs/Llama3.yaml
   # - model_configs/RandomForestModel.yaml
   # - model_configs/XGBoost.yaml
   # - model_configs/LightGBMModel.yaml
-  # - model_configs/CNNModel.yaml
-  # - model_configs/LSTMModel.yaml
-  # - model_configs/InceptionTimeModel.yaml
-  # - model_configs/GRUModel.yaml
+  - model_configs/CNNModel.yaml
+  - model_configs/LSTMModel.yaml
+  - model_configs/InceptionTimeModel.yaml
+  - model_configs/GRUModel.yaml

--- a/docs/results.json
+++ b/docs/results.json
@@ -1,697 +1,1329 @@
 {
-  "results": [
-    {
-      "model_id": "RandomForest",
-      "task_id": "mortality",
-      "dataset": "hirid",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.916,
-          "auprc": 0.642,
-          "normalized_auprc": 5.833,
-          "sensitivity": 0.182,
-          "specificity": 1.0,
-          "f1_score": 0.308,
-          "accuracy": 0.91,
-          "balanced_accuracy": 0.591,
-          "precision": 1.0,
-          "recall": 0.182,
-          "mcc": 0.406
+    "results": [
+        {
+            "model_id": "RandomForest",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.902,
+                    "auprc": 0.614,
+                    "normalized_auprc": 5.58,
+                    "sensitivity": 0.182,
+                    "specificity": 1.0,
+                    "f1_score": 0.308,
+                    "accuracy": 0.91,
+                    "balanced_accuracy": 0.591,
+                    "precision": 1.0,
+                    "recall": 0.182,
+                    "mcc": 0.406,
+                    "kappa": 0.283,
+                    "minpse": 0.5
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.823,
+                    "auprc": 0.652,
+                    "normalized_auprc": 5.434,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.88,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": 0.0,
+                    "kappa": 0.0,
+                    "minpse": 0.667
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.773,
+                    "auprc": 0.469,
+                    "normalized_auprc": 6.705,
+                    "sensitivity": 0.143,
+                    "specificity": 1.0,
+                    "f1_score": 0.25,
+                    "accuracy": 0.94,
+                    "balanced_accuracy": 0.571,
+                    "precision": 1.0,
+                    "recall": 0.143,
+                    "mcc": 0.366,
+                    "kappa": 0.237,
+                    "minpse": 0.429
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.741,
+                    "auprc": 0.27,
+                    "normalized_auprc": 3.051,
+                    "sensitivity": 0.008,
+                    "specificity": 1.0,
+                    "f1_score": 0.016,
+                    "accuracy": 0.912,
+                    "balanced_accuracy": 0.504,
+                    "precision": 1.0,
+                    "recall": 0.008,
+                    "mcc": 0.086,
+                    "kappa": 0.015,
+                    "minpse": 0.256
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.835,
+                    "auprc": 0.526,
+                    "normalized_auprc": 4.124,
+                    "sensitivity": 0.092,
+                    "specificity": 0.999,
+                    "f1_score": 0.167,
+                    "accuracy": 0.883,
+                    "balanced_accuracy": 0.545,
+                    "precision": 0.936,
+                    "recall": 0.092,
+                    "mcc": 0.273,
+                    "kappa": 0.148,
+                    "minpse": 0.468
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.741,
+                    "auprc": 0.346,
+                    "normalized_auprc": 2.368,
+                    "sensitivity": 0.235,
+                    "specificity": 0.948,
+                    "f1_score": 0.306,
+                    "accuracy": 0.844,
+                    "balanced_accuracy": 0.592,
+                    "precision": 0.438,
+                    "recall": 0.235,
+                    "mcc": 0.241,
+                    "kappa": 0.227,
+                    "minpse": 0.413
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.836,
+                    "auprc": 0.147,
+                    "normalized_auprc": 3.667,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.96,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": 0.0,
+                    "kappa": 0.0,
+                    "minpse": 0.183
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.646,
+                    "auprc": 0.015,
+                    "normalized_auprc": 1.394,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.989,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": 0.0,
+                    "kappa": 0.0,
+                    "minpse": 0.02
+                }
+            }
+        },
+        {
+            "model_id": "RandomForest",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250509_183704",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.597,
+                    "auprc": 0.031,
+                    "normalized_auprc": 1.809,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.983,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": 0.0,
+                    "kappa": 0.0,
+                    "minpse": 0.06
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.906,
+                    "auprc": 0.637,
+                    "normalized_auprc": 5.793,
+                    "sensitivity": 0.273,
+                    "specificity": 1.0,
+                    "f1_score": 0.429,
+                    "accuracy": 0.92,
+                    "balanced_accuracy": 0.636,
+                    "precision": 1.0,
+                    "recall": 0.273,
+                    "mcc": 0.5,
+                    "kappa": 0.4,
+                    "minpse": 0.545
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.879,
+                    "auprc": 0.464,
+                    "normalized_auprc": 3.863,
+                    "sensitivity": 0.0,
+                    "specificity": 0.989,
+                    "f1_score": 0.0,
+                    "accuracy": 0.87,
+                    "balanced_accuracy": 0.494,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.037,
+                    "kappa": -0.019,
+                    "minpse": 0.5
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.857,
+                    "auprc": 0.473,
+                    "normalized_auprc": 6.751,
+                    "sensitivity": 0.143,
+                    "specificity": 1.0,
+                    "f1_score": 0.25,
+                    "accuracy": 0.94,
+                    "balanced_accuracy": 0.571,
+                    "precision": 1.0,
+                    "recall": 0.143,
+                    "mcc": 0.366,
+                    "kappa": 0.237,
+                    "minpse": 0.429
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.807,
+                    "auprc": 0.394,
+                    "normalized_auprc": 4.459,
+                    "sensitivity": 0.116,
+                    "specificity": 0.998,
+                    "f1_score": 0.204,
+                    "accuracy": 0.92,
+                    "balanced_accuracy": 0.557,
+                    "precision": 0.829,
+                    "recall": 0.116,
+                    "mcc": 0.292,
+                    "kappa": 0.186,
+                    "minpse": 0.363
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.877,
+                    "auprc": 0.601,
+                    "normalized_auprc": 4.709,
+                    "sensitivity": 0.227,
+                    "specificity": 0.995,
+                    "f1_score": 0.36,
+                    "accuracy": 0.897,
+                    "balanced_accuracy": 0.611,
+                    "precision": 0.872,
+                    "recall": 0.227,
+                    "mcc": 0.414,
+                    "kappa": 0.325,
+                    "minpse": 0.546
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.826,
+                    "auprc": 0.538,
+                    "normalized_auprc": 3.684,
+                    "sensitivity": 0.271,
+                    "specificity": 0.983,
+                    "f1_score": 0.395,
+                    "accuracy": 0.879,
+                    "balanced_accuracy": 0.627,
+                    "precision": 0.731,
+                    "recall": 0.271,
+                    "mcc": 0.396,
+                    "kappa": 0.343,
+                    "minpse": 0.518
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.862,
+                    "auprc": 0.183,
+                    "normalized_auprc": 4.569,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.96,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.004,
+                    "kappa": -0.001,
+                    "minpse": 0.234
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.562,
+                    "auprc": 0.017,
+                    "normalized_auprc": 1.514,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.989,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.001,
+                    "kappa": -0.0,
+                    "minpse": 0.048
+                }
+            }
+        },
+        {
+            "model_id": "LightGBM",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250510_010444",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.693,
+                    "auprc": 0.033,
+                    "normalized_auprc": 1.921,
+                    "sensitivity": 0.0,
+                    "specificity": 1.0,
+                    "f1_score": 0.0,
+                    "accuracy": 0.983,
+                    "balanced_accuracy": 0.5,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": 0.0,
+                    "kappa": 0.0,
+                    "minpse": 0.088
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.806,
+                    "auprc": 0.531,
+                    "normalized_auprc": 4.831,
+                    "sensitivity": 0.273,
+                    "specificity": 1.0,
+                    "f1_score": 0.429,
+                    "accuracy": 0.92,
+                    "balanced_accuracy": 0.636,
+                    "precision": 1.0,
+                    "recall": 0.273,
+                    "mcc": 0.5,
+                    "kappa": 0.4,
+                    "minpse": 0.455
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.865,
+                    "auprc": 0.454,
+                    "normalized_auprc": 3.782,
+                    "sensitivity": 0.0,
+                    "specificity": 0.989,
+                    "f1_score": 0.0,
+                    "accuracy": 0.87,
+                    "balanced_accuracy": 0.494,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.037,
+                    "kappa": -0.019,
+                    "minpse": 0.583
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.817,
+                    "auprc": 0.45,
+                    "normalized_auprc": 6.43,
+                    "sensitivity": 0.286,
+                    "specificity": 1.0,
+                    "f1_score": 0.444,
+                    "accuracy": 0.95,
+                    "balanced_accuracy": 0.643,
+                    "precision": 1.0,
+                    "recall": 0.286,
+                    "mcc": 0.521,
+                    "kappa": 0.427,
+                    "minpse": 0.429
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.792,
+                    "auprc": 0.355,
+                    "normalized_auprc": 4.018,
+                    "sensitivity": 0.12,
+                    "specificity": 0.996,
+                    "f1_score": 0.207,
+                    "accuracy": 0.918,
+                    "balanced_accuracy": 0.558,
+                    "precision": 0.732,
+                    "recall": 0.12,
+                    "mcc": 0.275,
+                    "kappa": 0.187,
+                    "minpse": 0.36
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.882,
+                    "auprc": 0.605,
+                    "normalized_auprc": 4.744,
+                    "sensitivity": 0.248,
+                    "specificity": 0.99,
+                    "f1_score": 0.377,
+                    "accuracy": 0.895,
+                    "balanced_accuracy": 0.619,
+                    "precision": 0.783,
+                    "recall": 0.248,
+                    "mcc": 0.403,
+                    "kappa": 0.336,
+                    "minpse": 0.546
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.828,
+                    "auprc": 0.544,
+                    "normalized_auprc": 3.728,
+                    "sensitivity": 0.289,
+                    "specificity": 0.978,
+                    "f1_score": 0.408,
+                    "accuracy": 0.878,
+                    "balanced_accuracy": 0.634,
+                    "precision": 0.695,
+                    "recall": 0.289,
+                    "mcc": 0.395,
+                    "kappa": 0.353,
+                    "minpse": 0.524
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.839,
+                    "auprc": 0.174,
+                    "normalized_auprc": 4.328,
+                    "sensitivity": 0.009,
+                    "specificity": 0.998,
+                    "f1_score": 0.018,
+                    "accuracy": 0.958,
+                    "balanced_accuracy": 0.504,
+                    "precision": 0.167,
+                    "recall": 0.009,
+                    "mcc": 0.031,
+                    "kappa": 0.013,
+                    "minpse": 0.274
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.639,
+                    "auprc": 0.069,
+                    "normalized_auprc": 6.232,
+                    "sensitivity": 0.048,
+                    "specificity": 1.0,
+                    "f1_score": 0.091,
+                    "accuracy": 0.989,
+                    "balanced_accuracy": 0.524,
+                    "precision": 0.75,
+                    "recall": 0.048,
+                    "mcc": 0.189,
+                    "kappa": 0.09,
+                    "minpse": 0.054
+                }
+            }
+        },
+        {
+            "model_id": "XGBoost",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250510_011124",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.757,
+                    "auprc": 0.039,
+                    "normalized_auprc": 2.295,
+                    "sensitivity": 0.0,
+                    "specificity": 0.996,
+                    "f1_score": 0.0,
+                    "accuracy": 0.979,
+                    "balanced_accuracy": 0.498,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.008,
+                    "kappa": -0.006,
+                    "minpse": 0.054
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.819,
+                    "auprc": 0.464,
+                    "normalized_auprc": 4.222,
+                    "specificity": 0.921,
+                    "f1_score": 0.435,
+                    "accuracy": 0.87,
+                    "balanced_accuracy": 0.688,
+                    "precision": 0.417,
+                    "recall": 0.455,
+                    "mcc": 0.362,
+                    "kappa": 0.361,
+                    "minpse": 0.417
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.812,
+                    "auprc": 0.329,
+                    "normalized_auprc": 2.745,
+                    "specificity": 0.852,
+                    "f1_score": 0.438,
+                    "accuracy": 0.82,
+                    "balanced_accuracy": 0.718,
+                    "precision": 0.35,
+                    "recall": 0.583,
+                    "mcc": 0.354,
+                    "kappa": 0.338,
+                    "minpse": 0.412
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.794,
+                    "auprc": 0.429,
+                    "normalized_auprc": 6.136,
+                    "specificity": 0.86,
+                    "f1_score": 0.333,
+                    "accuracy": 0.84,
+                    "balanced_accuracy": 0.716,
+                    "precision": 0.235,
+                    "recall": 0.571,
+                    "mcc": 0.293,
+                    "kappa": 0.26,
+                    "minpse": 0.375
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.795,
+                    "auprc": 0.278,
+                    "normalized_auprc": 3.139,
+                    "specificity": 0.901,
+                    "f1_score": 0.405,
+                    "accuracy": 0.866,
+                    "balanced_accuracy": 0.707,
+                    "precision": 0.334,
+                    "recall": 0.514,
+                    "mcc": 0.343,
+                    "kappa": 0.334,
+                    "minpse": 0.356
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.823,
+                    "auprc": 0.521,
+                    "normalized_auprc": 4.087,
+                    "specificity": 0.865,
+                    "f1_score": 0.473,
+                    "accuracy": 0.831,
+                    "balanced_accuracy": 0.73,
+                    "precision": 0.392,
+                    "recall": 0.596,
+                    "mcc": 0.389,
+                    "kappa": 0.377,
+                    "minpse": 0.473
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.777,
+                    "auprc": 0.474,
+                    "normalized_auprc": 3.249,
+                    "specificity": 0.756,
+                    "f1_score": 0.429,
+                    "accuracy": 0.742,
+                    "balanced_accuracy": 0.71,
+                    "precision": 0.317,
+                    "recall": 0.664,
+                    "mcc": 0.322,
+                    "kappa": 0.289,
+                    "minpse": 0.446
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.557,
+                    "auprc": 0.068,
+                    "normalized_auprc": 1.693,
+                    "specificity": 0.953,
+                    "f1_score": 0.139,
+                    "accuracy": 0.921,
+                    "balanced_accuracy": 0.556,
+                    "precision": 0.123,
+                    "recall": 0.159,
+                    "mcc": 0.099,
+                    "kappa": 0.098,
+                    "minpse": 0.139
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.661,
+                    "auprc": 0.018,
+                    "normalized_auprc": 1.629,
+                    "specificity": 0.98,
+                    "f1_score": 0.0,
+                    "accuracy": 0.969,
+                    "balanced_accuracy": 0.49,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.015,
+                    "kappa": -0.014,
+                    "minpse": 0.025
+                }
+            }
+        },
+        {
+            "model_id": "CNN",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250512_164422",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.494,
+                    "auprc": 0.017,
+                    "normalized_auprc": 0.975,
+                    "specificity": 0.983,
+                    "f1_score": 0.01,
+                    "accuracy": 0.966,
+                    "balanced_accuracy": 0.496,
+                    "precision": 0.01,
+                    "recall": 0.01,
+                    "mcc": -0.007,
+                    "kappa": -0.007,
+                    "minpse": 0.026
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.845,
+                    "auprc": 0.576,
+                    "normalized_auprc": 5.233,
+                    "specificity": 0.966,
+                    "f1_score": 0.526,
+                    "accuracy": 0.91,
+                    "balanced_accuracy": 0.71,
+                    "precision": 0.625,
+                    "recall": 0.455,
+                    "mcc": 0.485,
+                    "kappa": 0.478,
+                    "minpse": 0.545
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.678,
+                    "auprc": 0.452,
+                    "normalized_auprc": 3.767,
+                    "specificity": 0.943,
+                    "f1_score": 0.455,
+                    "accuracy": 0.88,
+                    "balanced_accuracy": 0.68,
+                    "precision": 0.5,
+                    "recall": 0.417,
+                    "mcc": 0.39,
+                    "kappa": 0.388,
+                    "minpse": 0.417
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.823,
+                    "auprc": 0.322,
+                    "normalized_auprc": 4.604,
+                    "specificity": 0.989,
+                    "f1_score": 0.545,
+                    "accuracy": 0.95,
+                    "balanced_accuracy": 0.709,
+                    "precision": 0.75,
+                    "recall": 0.429,
+                    "mcc": 0.544,
+                    "kappa": 0.521,
+                    "minpse": 0.429
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.72,
+                    "auprc": 0.235,
+                    "normalized_auprc": 2.653,
+                    "specificity": 0.961,
+                    "f1_score": 0.206,
+                    "accuracy": 0.891,
+                    "balanced_accuracy": 0.561,
+                    "precision": 0.288,
+                    "recall": 0.161,
+                    "mcc": 0.16,
+                    "kappa": 0.152,
+                    "minpse": 0.274
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.757,
+                    "auprc": 0.407,
+                    "normalized_auprc": 3.194,
+                    "specificity": 0.861,
+                    "f1_score": 0.415,
+                    "accuracy": 0.816,
+                    "balanced_accuracy": 0.686,
+                    "precision": 0.35,
+                    "recall": 0.51,
+                    "mcc": 0.318,
+                    "kappa": 0.31,
+                    "minpse": 0.425
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.734,
+                    "auprc": 0.385,
+                    "normalized_auprc": 2.638,
+                    "specificity": 0.798,
+                    "f1_score": 0.399,
+                    "accuracy": 0.761,
+                    "balanced_accuracy": 0.67,
+                    "precision": 0.315,
+                    "recall": 0.543,
+                    "mcc": 0.277,
+                    "kappa": 0.262,
+                    "minpse": 0.4
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.765,
+                    "auprc": 0.154,
+                    "normalized_auprc": 3.84,
+                    "specificity": 0.991,
+                    "f1_score": 0.075,
+                    "accuracy": 0.954,
+                    "balanced_accuracy": 0.519,
+                    "precision": 0.185,
+                    "recall": 0.047,
+                    "mcc": 0.075,
+                    "kappa": 0.059,
+                    "minpse": 0.168
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.645,
+                    "auprc": 0.017,
+                    "normalized_auprc": 1.543,
+                    "specificity": 0.996,
+                    "f1_score": 0.0,
+                    "accuracy": 0.985,
+                    "balanced_accuracy": 0.498,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.006,
+                    "kappa": -0.006,
+                    "minpse": 0.031
+                }
+            }
+        },
+        {
+            "model_id": "LSTM",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250512_181250",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.678,
+                    "auprc": 0.029,
+                    "normalized_auprc": 1.684,
+                    "specificity": 0.982,
+                    "f1_score": 0.029,
+                    "accuracy": 0.966,
+                    "balanced_accuracy": 0.506,
+                    "precision": 0.028,
+                    "recall": 0.03,
+                    "mcc": 0.012,
+                    "kappa": 0.012,
+                    "minpse": 0.052
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.788,
+                    "auprc": 0.515,
+                    "normalized_auprc": 4.686,
+                    "specificity": 0.966,
+                    "f1_score": 0.6,
+                    "accuracy": 0.92,
+                    "balanced_accuracy": 0.756,
+                    "precision": 0.667,
+                    "recall": 0.545,
+                    "mcc": 0.56,
+                    "kappa": 0.556,
+                    "minpse": 0.545
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.751,
+                    "auprc": 0.258,
+                    "normalized_auprc": 2.15,
+                    "specificity": 0.932,
+                    "f1_score": 0.364,
+                    "accuracy": 0.86,
+                    "balanced_accuracy": 0.633,
+                    "precision": 0.4,
+                    "recall": 0.333,
+                    "mcc": 0.287,
+                    "kappa": 0.286,
+                    "minpse": 0.4
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.894,
+                    "auprc": 0.469,
+                    "normalized_auprc": 6.695,
+                    "specificity": 0.957,
+                    "f1_score": 0.308,
+                    "accuracy": 0.91,
+                    "balanced_accuracy": 0.621,
+                    "precision": 0.333,
+                    "recall": 0.286,
+                    "mcc": 0.261,
+                    "kappa": 0.26,
+                    "minpse": 0.333
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.755,
+                    "auprc": 0.264,
+                    "normalized_auprc": 2.981,
+                    "specificity": 0.864,
+                    "f1_score": 0.33,
+                    "accuracy": 0.83,
+                    "balanced_accuracy": 0.669,
+                    "precision": 0.253,
+                    "recall": 0.474,
+                    "mcc": 0.258,
+                    "kappa": 0.243,
+                    "minpse": 0.318
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.844,
+                    "auprc": 0.531,
+                    "normalized_auprc": 4.162,
+                    "specificity": 0.813,
+                    "f1_score": 0.456,
+                    "accuracy": 0.795,
+                    "balanced_accuracy": 0.743,
+                    "precision": 0.345,
+                    "recall": 0.673,
+                    "mcc": 0.375,
+                    "kappa": 0.346,
+                    "minpse": 0.497
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "aki",
+            "dataset": "eicu",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.801,
+                    "auprc": 0.498,
+                    "normalized_auprc": 3.412,
+                    "specificity": 0.761,
+                    "f1_score": 0.452,
+                    "accuracy": 0.752,
+                    "balanced_accuracy": 0.731,
+                    "precision": 0.334,
+                    "recall": 0.7,
+                    "mcc": 0.353,
+                    "kappa": 0.317,
+                    "minpse": 0.491
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "sepsis",
+            "dataset": "hirid",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.623,
+                    "auprc": 0.078,
+                    "normalized_auprc": 1.94,
+                    "specificity": 0.974,
+                    "f1_score": 0.13,
+                    "accuracy": 0.94,
+                    "balanced_accuracy": 0.543,
+                    "precision": 0.154,
+                    "recall": 0.112,
+                    "mcc": 0.101,
+                    "kappa": 0.099,
+                    "minpse": 0.14
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "sepsis",
+            "dataset": "miiv",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.442,
+                    "auprc": 0.009,
+                    "normalized_auprc": 0.839,
+                    "specificity": 0.993,
+                    "f1_score": 0.0,
+                    "accuracy": 0.982,
+                    "balanced_accuracy": 0.496,
+                    "precision": 0.0,
+                    "recall": 0.0,
+                    "mcc": -0.009,
+                    "kappa": -0.009,
+                    "minpse": 0.012
+                }
+            }
+        },
+        {
+            "model_id": "GRU",
+            "task_id": "sepsis",
+            "dataset": "eicu",
+            "run_id": "20250513_050347",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.694,
+                    "auprc": 0.032,
+                    "normalized_auprc": 1.87,
+                    "specificity": 0.991,
+                    "f1_score": 0.038,
+                    "accuracy": 0.975,
+                    "balanced_accuracy": 0.51,
+                    "precision": 0.054,
+                    "recall": 0.03,
+                    "mcc": 0.028,
+                    "kappa": 0.026,
+                    "minpse": 0.054
+                }
+            }
+        },
+        {
+            "model_id": "InceptionTime",
+            "task_id": "mortality",
+            "dataset": "hirid",
+            "run_id": "20250513_105007",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.871,
+                    "auprc": 0.618,
+                    "normalized_auprc": 5.623,
+                    "specificity": 0.82,
+                    "f1_score": 0.457,
+                    "accuracy": 0.81,
+                    "balanced_accuracy": 0.774,
+                    "precision": 0.333,
+                    "recall": 0.727,
+                    "mcc": 0.401,
+                    "kappa": 0.361,
+                    "minpse": 0.455
+                }
+            }
+        },
+        {
+            "model_id": "InceptionTime",
+            "task_id": "mortality",
+            "dataset": "miiv",
+            "run_id": "20250513_105007",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.862,
+                    "auprc": 0.595,
+                    "normalized_auprc": 4.959,
+                    "specificity": 0.784,
+                    "f1_score": 0.368,
+                    "accuracy": 0.76,
+                    "balanced_accuracy": 0.684,
+                    "precision": 0.269,
+                    "recall": 0.583,
+                    "mcc": 0.272,
+                    "kappa": 0.244,
+                    "minpse": 0.5
+                }
+            }
+        },
+        {
+            "model_id": "InceptionTime",
+            "task_id": "mortality",
+            "dataset": "eicu",
+            "run_id": "20250513_105007",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.863,
+                    "auprc": 0.464,
+                    "normalized_auprc": 6.628,
+                    "specificity": 0.925,
+                    "f1_score": 0.353,
+                    "accuracy": 0.89,
+                    "balanced_accuracy": 0.677,
+                    "precision": 0.3,
+                    "recall": 0.429,
+                    "mcc": 0.3,
+                    "kappa": 0.295,
+                    "minpse": 0.429
+                }
+            }
+        },
+        {
+            "model_id": "InceptionTime",
+            "task_id": "aki",
+            "dataset": "hirid",
+            "run_id": "20250513_105007",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.798,
+                    "auprc": 0.277,
+                    "normalized_auprc": 3.126,
+                    "specificity": 0.876,
+                    "f1_score": 0.355,
+                    "accuracy": 0.842,
+                    "balanced_accuracy": 0.683,
+                    "precision": 0.278,
+                    "recall": 0.49,
+                    "mcc": 0.287,
+                    "kappa": 0.273,
+                    "minpse": 0.375
+                }
+            }
+        },
+        {
+            "model_id": "InceptionTime",
+            "task_id": "aki",
+            "dataset": "miiv",
+            "run_id": "20250513_105007",
+            "metrics_summary": {
+                "overall": {
+                    "auroc": 0.84,
+                    "auprc": 0.554,
+                    "normalized_auprc": 4.345,
+                    "specificity": 0.921,
+                    "f1_score": 0.533,
+                    "accuracy": 0.875,
+                    "balanced_accuracy": 0.741,
+                    "precision": 0.509,
+                    "recall": 0.56,
+                    "mcc": 0.462,
+                    "kappa": 0.461,
+                    "minpse": 0.522
+                }
+            }
         }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "mortality",
-      "dataset": "miiv",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.842,
-          "auprc": 0.715,
-          "normalized_auprc": 5.954,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.88,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "mortality",
-      "dataset": "eicu",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.802,
-          "auprc": 0.446,
-          "normalized_auprc": 6.375,
-          "sensitivity": 0.143,
-          "specificity": 1.0,
-          "f1_score": 0.25,
-          "accuracy": 0.94,
-          "balanced_accuracy": 0.571,
-          "precision": 1.0,
-          "recall": 0.143,
-          "mcc": 0.366
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "aki",
-      "dataset": "hirid",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.754,
-          "auprc": 0.292,
-          "normalized_auprc": 3.3,
-          "sensitivity": 0.004,
-          "specificity": 1.0,
-          "f1_score": 0.008,
-          "accuracy": 0.912,
-          "balanced_accuracy": 0.502,
-          "precision": 1.0,
-          "recall": 0.004,
-          "mcc": 0.061
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "aki",
-      "dataset": "miiv",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.859,
-          "auprc": 0.56,
-          "normalized_auprc": 4.391,
-          "sensitivity": 0.094,
-          "specificity": 0.999,
-          "f1_score": 0.171,
-          "accuracy": 0.884,
-          "balanced_accuracy": 0.547,
-          "precision": 0.957,
-          "recall": 0.094,
-          "mcc": 0.28
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "aki",
-      "dataset": "eicu",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.76,
-          "auprc": 0.376,
-          "normalized_auprc": 2.575,
-          "sensitivity": 0.209,
-          "specificity": 0.953,
-          "f1_score": 0.282,
-          "accuracy": 0.845,
-          "balanced_accuracy": 0.581,
-          "precision": 0.434,
-          "recall": 0.209,
-          "mcc": 0.224
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "sepsis",
-      "dataset": "hirid",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.872,
-          "auprc": 0.185,
-          "normalized_auprc": 4.619,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.96,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "sepsis",
-      "dataset": "miiv",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.478,
-          "auprc": 0.01,
-          "normalized_auprc": 0.877,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.989,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "RandomForest",
-      "task_id": "sepsis",
-      "dataset": "eicu",
-      "run_id": "20250429_080008",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.655,
-          "auprc": 0.039,
-          "normalized_auprc": 2.302,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.983,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "mortality",
-      "dataset": "hirid",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.877,
-          "auprc": 0.568,
-          "normalized_auprc": 5.168,
-          "sensitivity": 0.273,
-          "specificity": 1.0,
-          "f1_score": 0.429,
-          "accuracy": 0.92,
-          "balanced_accuracy": 0.636,
-          "precision": 1.0,
-          "recall": 0.273,
-          "mcc": 0.5
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "mortality",
-      "dataset": "miiv",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.887,
-          "auprc": 0.62,
-          "normalized_auprc": 5.169,
-          "sensitivity": 0.083,
-          "specificity": 1.0,
-          "f1_score": 0.154,
-          "accuracy": 0.89,
-          "balanced_accuracy": 0.542,
-          "precision": 1.0,
-          "recall": 0.083,
-          "mcc": 0.272
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "mortality",
-      "dataset": "eicu",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.845,
-          "auprc": 0.436,
-          "normalized_auprc": 6.227,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.93,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "aki",
-      "dataset": "hirid",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.811,
-          "auprc": 0.393,
-          "normalized_auprc": 4.439,
-          "sensitivity": 0.048,
-          "specificity": 0.999,
-          "f1_score": 0.091,
-          "accuracy": 0.915,
-          "balanced_accuracy": 0.524,
-          "precision": 0.857,
-          "recall": 0.048,
-          "mcc": 0.191
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "aki",
-      "dataset": "miiv",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.876,
-          "auprc": 0.621,
-          "normalized_auprc": 4.866,
-          "sensitivity": 0.173,
-          "specificity": 0.997,
-          "f1_score": 0.29,
-          "accuracy": 0.892,
-          "balanced_accuracy": 0.585,
-          "precision": 0.892,
-          "recall": 0.173,
-          "mcc": 0.365
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "aki",
-      "dataset": "eicu",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.815,
-          "auprc": 0.522,
-          "normalized_auprc": 3.575,
-          "sensitivity": 0.232,
-          "specificity": 0.991,
-          "f1_score": 0.361,
-          "accuracy": 0.88,
-          "balanced_accuracy": 0.612,
-          "precision": 0.813,
-          "recall": 0.232,
-          "mcc": 0.394
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "sepsis",
-      "dataset": "hirid",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.875,
-          "auprc": 0.221,
-          "normalized_auprc": 5.513,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.96,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "sepsis",
-      "dataset": "miiv",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.558,
-          "auprc": 0.019,
-          "normalized_auprc": 1.712,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.989,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "XGBoost",
-      "task_id": "sepsis",
-      "dataset": "eicu",
-      "run_id": "20250429_091158",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.688,
-          "auprc": 0.033,
-          "normalized_auprc": 1.953,
-          "sensitivity": 0.0,
-          "specificity": 1.0,
-          "f1_score": 0.0,
-          "accuracy": 0.983,
-          "balanced_accuracy": 0.5,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": 0.0
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "mortality",
-      "dataset": "hirid",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.815,
-          "auprc": 0.51,
-          "normalized_auprc": 4.635,
-          "sensitivity": 0.364,
-          "specificity": 0.989,
-          "f1_score": 0.5,
-          "accuracy": 0.92,
-          "balanced_accuracy": 0.676,
-          "precision": 0.8,
-          "recall": 0.364,
-          "mcc": 0.506
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "mortality",
-      "dataset": "miiv",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.856,
-          "auprc": 0.453,
-          "normalized_auprc": 3.777,
-          "sensitivity": 0.167,
-          "specificity": 0.989,
-          "f1_score": 0.267,
-          "accuracy": 0.89,
-          "balanced_accuracy": 0.578,
-          "precision": 0.667,
-          "recall": 0.167,
-          "mcc": 0.296
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "mortality",
-      "dataset": "eicu",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.912,
-          "auprc": 0.513,
-          "normalized_auprc": 7.328,
-          "sensitivity": 0.286,
-          "specificity": 1.0,
-          "f1_score": 0.444,
-          "accuracy": 0.95,
-          "balanced_accuracy": 0.643,
-          "precision": 1.0,
-          "recall": 0.286,
-          "mcc": 0.521
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "aki",
-      "dataset": "hirid",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.737,
-          "auprc": 0.192,
-          "normalized_auprc": 2.273,
-          "sensitivity": 0.169,
-          "specificity": 0.939,
-          "f1_score": 0.185,
-          "accuracy": 0.874,
-          "balanced_accuracy": 0.554,
-          "precision": 0.203,
-          "recall": 0.169,
-          "mcc": 0.118
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "aki",
-      "dataset": "miiv",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.768,
-          "auprc": 0.447,
-          "normalized_auprc": 3.71,
-          "sensitivity": 0.316,
-          "specificity": 0.974,
-          "f1_score": 0.42,
-          "accuracy": 0.895,
-          "balanced_accuracy": 0.645,
-          "precision": 0.624,
-          "recall": 0.316,
-          "mcc": 0.394
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "aki",
-      "dataset": "eicu",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.759,
-          "auprc": 0.389,
-          "normalized_auprc": 2.765,
-          "sensitivity": 0.294,
-          "specificity": 0.943,
-          "f1_score": 0.358,
-          "accuracy": 0.851,
-          "balanced_accuracy": 0.618,
-          "precision": 0.456,
-          "recall": 0.294,
-          "mcc": 0.287
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "sepsis",
-      "dataset": "hirid",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.581,
-          "auprc": 0.073,
-          "normalized_auprc": 1.783,
-          "sensitivity": 0.056,
-          "specificity": 0.993,
-          "f1_score": 0.092,
-          "accuracy": 0.954,
-          "balanced_accuracy": 0.524,
-          "precision": 0.25,
-          "recall": 0.056,
-          "mcc": 0.101
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "sepsis",
-      "dataset": "miiv",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.648,
-          "auprc": 0.012,
-          "normalized_auprc": 1.338,
-          "sensitivity": 0.0,
-          "specificity": 0.995,
-          "f1_score": 0.0,
-          "accuracy": 0.986,
-          "balanced_accuracy": 0.498,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": -0.007
-        }
-      }
-    },
-    {
-      "model_id": "CNN",
-      "task_id": "sepsis",
-      "dataset": "eicu",
-      "run_id": "20250429_120045",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.49,
-          "auprc": 0.017,
-          "normalized_auprc": 1.001,
-          "sensitivity": 0.0,
-          "specificity": 0.997,
-          "f1_score": 0.0,
-          "accuracy": 0.98,
-          "balanced_accuracy": 0.499,
-          "precision": 0.0,
-          "recall": 0.0,
-          "mcc": -0.007
-        }
-      }
-    },
-    {
-      "model_id": "GRU",
-      "task_id": "mortality",
-      "dataset": "hirid",
-      "run_id": "20250508_011500",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.741,
-          "auprc": 0.587,
-          "normalized_auprc": 4.173,
-          "sensitivity": 0.556,
-          "specificity": 0.927,
-          "f1_score": 0.556,
-          "accuracy": 0.875,
-          "balanced_accuracy": 0.741,
-          "precision": 0.556,
-          "recall": 0.556,
-          "mcc": 0.483
-        }
-      }
-    },
-    {
-      "model_id": "GRU",
-      "task_id": "aki",
-      "dataset": "hirid",
-      "run_id": "20250508_011500",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.695,
-          "auprc": 0.417,
-          "normalized_auprc": 4.858,
-          "sensitivity": 0.551,
-          "specificity": 0.84,
-          "f1_score": 0.338,
-          "accuracy": 0.815,
-          "balanced_accuracy": 0.695,
-          "precision": 0.244,
-          "recall": 0.551,
-          "mcc": 0.277
-        }
-      }
-    },
-    {
-      "model_id": "GRU",
-      "task_id": "sepsis",
-      "dataset": "hirid",
-      "run_id": "20250508_011500",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.525,
-          "auprc": 0.125,
-          "normalized_auprc": 3.058,
-          "sensitivity": 0.065,
-          "specificity": 0.984,
-          "f1_score": 0.09,
-          "accuracy": 0.946,
-          "balanced_accuracy": 0.525,
-          "precision": 0.146,
-          "recall": 0.065,
-          "mcc": 0.073
-        }
-      }
-    },
-    {
-      "model_id": "InceptionTime",
-      "task_id": "mortality",
-      "dataset": "hirid",
-      "run_id": "20250508_011624",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.678,
-          "auprc": 0.465,
-          "normalized_auprc": 3.309,
-          "sensitivity": 0.556,
-          "specificity": 0.8,
-          "f1_score": 0.4,
-          "accuracy": 0.766,
-          "balanced_accuracy": 0.678,
-          "precision": 0.312,
-          "recall": 0.556,
-          "mcc": 0.285
-        }
-      }
-    },
-    {
-      "model_id": "InceptionTime",
-      "task_id": "aki",
-      "dataset": "hirid",
-      "run_id": "20250508_011624",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.698,
-          "auprc": 0.428,
-          "normalized_auprc": 4.993,
-          "sensitivity": 0.614,
-          "specificity": 0.782,
-          "f1_score": 0.312,
-          "accuracy": 0.767,
-          "balanced_accuracy": 0.698,
-          "precision": 0.209,
-          "recall": 0.614,
-          "mcc": 0.255
-        }
-      }
-    },
-    {
-      "model_id": "InceptionTime",
-      "task_id": "sepsis",
-      "dataset": "hirid",
-      "run_id": "20250508_011624",
-      "metrics_summary": {
-        "overall": {
-          "auroc": 0.5,
-          "auprc": 0.52,
-          "normalized_auprc": 12.762,
-          "sensitivity": 1.0,
-          "specificity": 0.0,
-          "f1_score": 0.078,
-          "accuracy": 0.041,
-          "balanced_accuracy": 0.5,
-          "precision": 0.041,
-          "recall": 1.0,
-          "mcc": 0.0
-        }
-      }
-    }
-  ]
+    ]
 }

--- a/model_configs/CNNModel.yaml
+++ b/model_configs/CNNModel.yaml
@@ -8,9 +8,10 @@ params:
   verbose: 2 # Controls verbosity of output (0 = silent, 1 = log every 100 batches, 2 = log every batch)
   
   # Model Architecture
-  output_shape: 1
+  output_shape: 1 # binary classification
   kernel_size: [1, 3, 5] # Kernel sizes for convolutional layers
   pool_size: 2
+  dropout_rate: 0.3
   
   # Training
   num_epochs: 100

--- a/model_configs/GRUModel.yaml
+++ b/model_configs/GRUModel.yaml
@@ -9,8 +9,8 @@ params:
   
   # Model Architecture
   hidden_size: 64
-  num_layers: 2
-  dropout_rate: 0.3
+  num_layers: 3
+  dropout_rate: [0.2, 0.3, 0.3, 0.4, 0.5]  # First 3 for GRU layers, last 2 for FC layers
   fc_layers: [64, 16]
   activation: "leaky_relu" # Activation function (relu, leaky_relu, gelu)
   

--- a/model_configs/LSTMModel.yaml
+++ b/model_configs/LSTMModel.yaml
@@ -8,9 +8,11 @@ params:
   verbose: 2 # Controls verbosity of output (0 = silent, 1 = log every 100 batches, 2 = log every batch)
   
   # Model Architecture
-  hidden_size: 150 # Number of hidden units in LSTM layers
-  num_layers: 2 # Number of LSTM layers
-  dropout: 0.2 # Dropout rate for LSTM layers
+  hidden_size: 64 # Number of hidden units in LSTM layers
+  num_layers: 3 # Number of LSTM layers (should match length of lstm_units)
+  lstm_units: [256, 128, 64] # Number of units in each LSTM layer
+  dense_units: 64 # Number of units in the first dense layer
+  dropout: [0.2, 0.3, 0.4] # Dropout rate for LSTM layers, can be single value or list
   output_shape: 1
   
   # Training

--- a/model_configs/LightGBMModel.yaml
+++ b/model_configs/LightGBMModel.yaml
@@ -4,7 +4,6 @@ params:
   # Basic configuration
   trainer_name: "LightGBMTrainer" # Class that implements the training process
   type: "convML" # Type of model (convML for conventional machine learning, convDL for conventional deep learning and LLM for large language models)
-  random_state: 42 # Seed for reproducible results
   verbose: -1 # Controls the level of logging output (-1: silent, >=0: logging)
   n_jobs: -1 # Number of parallel threads (-1 to use all CPUs)
   

--- a/model_configs/RandomForestModel.yaml
+++ b/model_configs/RandomForestModel.yaml
@@ -4,7 +4,6 @@ params:
   # Basic configuration
   type: "convML" # Type of model (convML for conventional machine learning, convDL for conventional deep learning and LLM for large language models)
   trainer_name: "RandomForestTrainer" # Class that implements the training process
-  random_state: 42 # Seed for reproducible results
   verbose: 0 # Controls verbosity of output (0: silent, 1: progress bar, >1: more details)
   tune_hyperparameters: false # Whether to tune hyperparameters (true/false)
   n_jobs: -1 # Number of CPU cores to use (-1 for all available, None for 1 CPU)

--- a/model_configs/XGBoost.yaml
+++ b/model_configs/XGBoost.yaml
@@ -5,7 +5,6 @@ params:
   trainer_name: "XGBoostTrainer" # Class that implements the training process
   type: "convML" # Type of model (convML for conventional machine learning, convDL for conventional deep learning and LLM for large language models)
   tune_hyperparameters: false # Whether to tune hyperparameters
-  random_state: 42 # Seed for reproducible results
   verbosity: 0 # Controls the level of logging output (0: silent, 1: warnings, 2: info)
   n_jobs: -1 # Number of parallel threads (-1 to use all CPUs)
   

--- a/notebooks/put_scrappy_nb_here.txt
+++ b/notebooks/put_scrappy_nb_here.txt
@@ -1,1 +1,0 @@
-the place for scrappy notebooks for quick evaluations and debugging

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import os
 import sys
@@ -550,6 +551,22 @@ class DatasetManager:
                         data_dict[split]["y"] = y_data.drop(columns=["stay_id"])
 
         return data_dict
+
+    def release_dataset_cache(self, dataset_id=None):
+        """Release cached data for a specific dataset or all datasets."""
+        if dataset_id:
+            if dataset_id in self.datasets and self.datasets[dataset_id]["loaded"]:
+                self.datasets[dataset_id]["data"] = None
+                self.datasets[dataset_id]["loaded"] = False
+                logger.debug("Released cached data for %s", dataset_id)
+                gc.collect()
+        else:
+            for ds_id, dataset in self.datasets.items():
+                if dataset["loaded"]:
+                    dataset["data"] = None
+                    dataset["loaded"] = False
+            logger.debug("Released all cached datasets")
+            gc.collect()
 
 
 class TorchDatasetWrapper(Dataset):

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -413,17 +413,33 @@ class DatasetManager:
             print_stats = kwargs.get("print_stats", False)  # set in train_models.py
             if print_stats:
                 train_stats = self.preprocessor.calculate_dataset_statistics(
-                    data["X_train"], data["y_train"], "train"
+                    data["X_train"],
+                    data["y_train"],
+                    "train",
+                    task=dataset["task"],
+                    dataset_name=dataset["name"],
                 )
                 val_stats = self.preprocessor.calculate_dataset_statistics(
-                    data["X_val"], data["y_val"], "val"
+                    data["X_val"],
+                    data["y_val"],
+                    "val",
+                    task=dataset["task"],
+                    dataset_name=dataset["name"],
                 )
                 test_stats = self.preprocessor.calculate_dataset_statistics(
-                    X_original, y_original, "test"
+                    X_original,
+                    y_original,
+                    "test",
+                    task=dataset["task"],
+                    dataset_name=dataset["name"],
                 )
                 if self.test_limited is not None:
                     test_limited_stats = self.preprocessor.calculate_dataset_statistics(
-                        X_limited, y_limited, f"test_limited{self.test_limited}"
+                        X_limited,
+                        y_limited,
+                        f"test_limited{self.test_limited}",
+                        task=dataset["task"],
+                        dataset_name=dataset["name"],
                     )
                 else:
                     test_limited_stats = None

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -9,6 +9,7 @@ import pandas as pd
 import torch
 from torch.utils.data import Dataset
 
+from src.util.config_util import set_seeds
 from src.preprocessing.preprocessing_advanced.windowing import Windower
 from src.preprocessing.preprocessing_baseline.preprocessing_baseline import (
     PreprocessorBaseline,
@@ -65,7 +66,8 @@ class DatasetManager:
     def _init_preprocessing_tools(self):
         """Initialize preprocessing tools based on configuration."""
         base_path = self.config.base_path
-        random_seed = self.config.random_seed
+        random_seed = self.config.benchmark_settings.random_seed
+        set_seeds(random_seed)
 
         # Get debug_mode from config - using attribute style
         debug_mode = False

--- a/src/data/dataloader.py
+++ b/src/data/dataloader.py
@@ -460,6 +460,14 @@ class DatasetManager:
             "Dropped stay_id column from X and y (including for few-shot examples)"
         )
 
+        # Convert categorical columns to numerical values for convML models
+        convML_models = ["RandomForest", "XGBoost", "LightGBM"]
+        if any(mdl in model_name for mdl in convML_models):
+            # Process gender column in X if it exists
+            if isinstance(X, pd.DataFrame) and "sex" in X.columns:
+                X["sex"] = X["sex"].map({"Male": 1, "Female": 0}).fillna(-1)
+                logger.debug("Converted gender column to numerical values")
+
         # Apply any model-specific preprocessing if needed.
         # For example, if you need to tokenize text data for LLMs
         if prompting_id is not None:

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 import numpy as np
 import pandas as pd
@@ -539,7 +539,7 @@ def calculate_minpse(
 def calculate_all_metrics(
     y_true: Union[np.ndarray, torch.Tensor],
     y_pred: Union[np.ndarray, torch.Tensor],
-    threshold: float = 0.5,
+    threshold: Optional[float] = None,
 ) -> Dict[str, float]:
     """
     Calculate all metrics at once
@@ -552,6 +552,14 @@ def calculate_all_metrics(
     Returns:
         Dictionary containing all metrics rounded to 3 decimal places
     """
+    # Auto-detect if predictions are logits or probabilities
+    if threshold is None:
+        # If predictions contain values outside [0,1], they're likely logits
+        if np.any((y_pred < 0) | (y_pred > 1)):
+            threshold = 0.0  # For logits, threshold at 0
+        else:
+            threshold = 0.5  # For probabilities, threshold at 0.5
+
     # Get both AUPRC and normalized AUPRC in one call
     auprc_results = calculate_auprc(y_true, y_pred)
 

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -61,6 +61,8 @@ class MetricsTracker:
             "precision",
             "recall",
             "mcc",
+            "kappa",
+            "minpse",
         ]
         self.metrics = {metric: [] for metric in self.metrics_to_track}
         self.results = {
@@ -143,7 +145,8 @@ class MetricsTracker:
                         existing_data = [existing_data]
             except json.JSONDecodeError:
                 logger.warning(
-                    f"Could not decode existing JSON in {report_path}, creating new file"
+                    "Could not decode existing JSON in %s, creating new file",
+                    report_path,
                 )
                 existing_data = []
 
@@ -450,7 +453,8 @@ def calculate_mcc(
     threshold: float = 0.5,
 ) -> float:
     """
-    Calculate Matthews Correlation Coefficient (MCC)
+    Calculate Matthews Correlation Coefficient (MCC) (-1: total disagreement,
+    0: random prediction, 1: perfect prediction)
 
     Args:
         y_true: Ground truth labels (0 or 1)

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -53,7 +53,6 @@ class MetricsTracker:
             "auroc",
             "auprc",
             "normalized_auprc",
-            "sensitivity",
             "specificity",
             "f1_score",
             "accuracy",
@@ -247,35 +246,6 @@ def calculate_auprc(
         normalized_auprc = auprc / positive_fraction
 
     return {"auprc": auprc, "normalized_auprc": normalized_auprc}
-
-
-def calculate_sensitivity(
-    y_true: Union[np.ndarray, torch.Tensor],
-    y_pred: Union[np.ndarray, torch.Tensor],
-    threshold: float = 0.5,
-) -> float:
-    """
-    Calculate Sensitivity (Recall or True Positive Rate)
-
-    Args:
-        y_true: Ground truth labels (0 or 1)
-        y_pred: Predicted probabilities
-        threshold: Threshold to convert probabilities to binary predictions
-
-    Returns:
-        Sensitivity score
-    """
-    # Handle tensors if passed
-    if isinstance(y_true, torch.Tensor):
-        y_true = y_true.detach().cpu().numpy()
-    if isinstance(y_pred, torch.Tensor):
-        y_pred = y_pred.detach().cpu().numpy()
-
-    # Convert probabilities to binary predictions
-    y_pred_binary = (y_pred >= threshold).astype(int)
-
-    tn, fp, fn, tp = confusion_matrix(y_true, y_pred_binary, labels=[0, 1]).ravel()
-    return tp / (tp + fn) if (tp + fn) > 0 else 0
 
 
 def calculate_specificity(
@@ -574,13 +544,14 @@ def calculate_all_metrics(
         "auroc": calculate_auroc(y_true, y_pred),
         "auprc": auprc_results["auprc"],
         "normalized_auprc": auprc_results["normalized_auprc"],
-        "sensitivity": calculate_sensitivity(y_true, y_pred, threshold),
         "specificity": calculate_specificity(y_true, y_pred, threshold),
         "f1_score": calculate_f1_score(y_true, y_pred, threshold),
         "accuracy": calculate_accuracy(y_true, y_pred, threshold),
         "balanced_accuracy": calculate_balanced_accuracy(y_true, y_pred, threshold),
         "precision": calculate_precision(y_true, y_pred, threshold),
-        "recall": calculate_recall(y_true, y_pred, threshold),
+        "recall": calculate_recall(
+            y_true, y_pred, threshold
+        ),  # is the same as sensitivity
         "mcc": calculate_mcc(y_true, y_pred, threshold),
         "kappa": calculate_kappa(y_true, y_pred, threshold),
         "minpse": calculate_minpse(y_true, y_pred),

--- a/src/models/cnn_model.py
+++ b/src/models/cnn_model.py
@@ -11,6 +11,7 @@ import torch.optim as optim
 import wandb
 from src.eval.metrics import MetricsTracker
 from src.models.pulsetemplate_model import PulseTemplateModel
+from src.util.config_util import set_seeds
 from src.util.model_util import (
     EarlyStopping,
     prepare_data_for_model_convdl,
@@ -258,6 +259,15 @@ class CNNTrainer:
 
     def train(self):
         """Training loop."""
+        # Set random seed from params if available
+        if "random_seed" in self.params:
+            set_seeds(self.params["random_seed"])
+            logger.debug(
+                "Random seed set to %d before %s training",
+                self.params["random_seed"],
+                self.model.model_name,
+            )
+
         num_epochs = self.params["num_epochs"]
         verbose = self.params.get("verbose", 1)
 

--- a/src/models/cnn_model.py
+++ b/src/models/cnn_model.py
@@ -201,7 +201,6 @@ class CNNTrainer:
         self.early_stopping = EarlyStopping(
             patience=self.params["early_stopping_rounds"],
             verbose=True,
-            delta=0.0,
         )
         self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
             self.optimizer,

--- a/src/models/cnn_model.py
+++ b/src/models/cnn_model.py
@@ -54,6 +54,7 @@ class CNNModel(PulseTemplateModel, nn.Module):
             "output_shape",
             "kernel_size",
             "pool_size",
+            "dropout_rate",
             "learning_rate",
             "num_epochs",
             "early_stopping_rounds",
@@ -127,7 +128,7 @@ class CNNModel(PulseTemplateModel, nn.Module):
         self.leaky_relu = nn.LeakyReLU()
 
         self.pool = nn.MaxPool1d(kernel_size=self.params["pool_size"])
-        self.dropout = nn.Dropout(0.1)
+        self.dropout = nn.Dropout(self.params["dropout_rate"])
         self.flatten = nn.Flatten()
 
         # Dummy forward to calculate fc1 input size

--- a/src/models/gru_model.py
+++ b/src/models/gru_model.py
@@ -10,6 +10,7 @@ import torch.optim as optim
 import wandb
 from src.eval.metrics import MetricsTracker
 from src.models.pulsetemplate_model import PulseTemplateModel
+from src.util.config_util import set_seeds
 from src.util.model_util import (
     EarlyStopping,
     prepare_data_for_model_convdl,
@@ -380,6 +381,15 @@ class GRUTrainer:
 
     def train(self):
         """Train the GRU model using the provided data loaders."""
+        # Set random seed from params if available
+        if "random_seed" in self.params:
+            set_seeds(self.params["random_seed"])
+            logger.debug(
+                "Random seed set to %d before %s training",
+                self.params["random_seed"],
+                self.model.model_name,
+            )
+
         # Move to GPU if available
         self.model.to(self.device)
         self.criterion.to(self.device)

--- a/src/models/gru_model.py
+++ b/src/models/gru_model.py
@@ -525,7 +525,7 @@ class GRUTrainer:
                 batch_metrics.append(batch_accuracy)
 
                 # Add results to metrics tracker
-                metrics_tracker.add_results(preds.cpu().numpy(), labels.cpu().numpy())
+                metrics_tracker.add_results(outputs.cpu().numpy(), labels.cpu().numpy())
 
                 # Log batch progress if verbose
                 if self.params["verbose"] == 2 or (

--- a/src/models/gru_model.py
+++ b/src/models/gru_model.py
@@ -442,6 +442,9 @@ class GRUTrainer:
         for batch_idx, (features, labels) in enumerate(self.train_loader):
             features = self.converter.convert_batch_to_3d(features)
             features, labels = features.to(self.device), labels.to(self.device).float()
+            # Log device information for the first batch
+            if batch_idx == 0:
+                logger.debug("Training batch on device: %s", features.device)
 
             # Forward pass
             self.optimizer.zero_grad()

--- a/src/models/inceptiontime_model.py
+++ b/src/models/inceptiontime_model.py
@@ -22,8 +22,6 @@ from src.util.model_util import (
 # Set up logger
 logger = logging.getLogger("PULSE_logger")
 
-# TODO: implement load presaved model weights from path (specified in config)
-
 
 class InceptionTimeModel(PulseTemplateModel, nn.Module):
     """
@@ -503,6 +501,9 @@ class InceptionTimeTrainer:
         for batch_idx, (features, labels) in enumerate(self.train_loader):
             features = self.converter.convert_batch_to_3d(features)
             features, labels = features.to(self.device), labels.to(self.device).float()
+            # Log device information for the first batch
+            if batch_idx == 0:
+                logger.debug("Training batch on device: %s", features.device)
 
             # Forward pass
             self.optimizer.zero_grad()

--- a/src/models/inceptiontime_model.py
+++ b/src/models/inceptiontime_model.py
@@ -11,6 +11,7 @@ import torch.optim as optim
 import wandb
 from src.eval.metrics import MetricsTracker
 from src.models.pulsetemplate_model import PulseTemplateModel
+from src.util.config_util import set_seeds
 from src.util.model_util import (
     EarlyStopping,
     prepare_data_for_model_convdl,
@@ -440,6 +441,14 @@ class InceptionTimeTrainer:
 
     def train(self):
         """Training loop."""
+        # Set random seed from params if available
+        if "random_seed" in self.params:
+            set_seeds(self.params["random_seed"])
+            logger.debug(
+                "Random seed set to %d before %s training",
+                self.params["random_seed"],
+                self.model.model_name,
+            )
 
         # Move to GPU if available
         self.model.to(self.device)

--- a/src/models/inceptiontime_model.py
+++ b/src/models/inceptiontime_model.py
@@ -620,7 +620,7 @@ class InceptionTimeTrainer:
                 batch_metrics.append(batch_accuracy)
 
                 # Add results to metrics tracker
-                metrics_tracker.add_results(preds.cpu().numpy(), labels.cpu().numpy())
+                metrics_tracker.add_results(outputs.cpu().numpy(), labels.cpu().numpy())
 
                 # Log batch progress if verbose
                 if self.params["verbose"] == 2 or (

--- a/src/models/lightgbm_model.py
+++ b/src/models/lightgbm_model.py
@@ -3,7 +3,6 @@ import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
-import numpy as np
 import pandas as pd
 from lightgbm import LGBMClassifier, early_stopping
 from sklearn.metrics import confusion_matrix
@@ -60,7 +59,6 @@ class LightGBMModel(PulseTemplateModel):
             "objective",
             "n_estimators",
             "learning_rate",
-            "random_state",
             "verbose",
             "max_depth",
             "num_leaves",
@@ -91,9 +89,10 @@ class LightGBMModel(PulseTemplateModel):
             for param in required_lgb_params
             if param != "early_stopping_rounds"
         }
+        model_params["random_state"] = params.get("random_seed")
 
         # Log the parameters being used
-        logger.info(f"Initializing LightGBM with parameters: {model_params}")
+        logger.info("Initializing LightGBM with parameters: %s", model_params)
 
         # Initialize the LightGBM model with parameters from config
         self.model = LGBMClassifier(**model_params)
@@ -208,8 +207,8 @@ class LightGBMTrainer:
         metrics_tracker.save_report()
 
         # Log results to console
-        logger.info(f"Test evaluation completed for {self.model.model_name}")
-        logger.info(f"Test metrics: {metrics_tracker.summary}")
+        logger.info("Test evaluation completed for %s", self.model.model_name)
+        logger.info("Test metrics: %s", metrics_tracker.summary)
 
         # Save the model
         model_save_name = f"{self.model.model_name}_{self.task_name}_{self.dataset_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.pt"
@@ -226,7 +225,6 @@ class LightGBMTrainer:
 
             # Create and log confusion matrix
             y_pred_binary = (y_pred >= 0.5).astype(int)
-            cm = confusion_matrix(y_test, y_pred_binary)
             wandb.log(
                 {
                     "confusion_matrix": wandb.plot.confusion_matrix(

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -11,6 +11,7 @@ import torch.optim as optim
 import wandb
 from src.eval.metrics import MetricsTracker
 from src.models.pulsetemplate_model import PulseTemplateModel
+from src.util.config_util import set_seeds
 from src.util.model_util import (
     EarlyStopping,
     prepare_data_for_model_convdl,
@@ -288,6 +289,15 @@ class LSTMTrainer:
 
     def train(self):
         """Training loop."""
+        # Set random seed from params if available
+        if "random_seed" in self.params:
+            set_seeds(self.params["random_seed"])
+            logger.debug(
+                "Random seed set to %d before %s training",
+                self.params["random_seed"],
+                self.model.model_name,
+            )
+
         num_epochs = self.params["num_epochs"]
         verbose = self.params.get("verbose", 1)
 

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -222,7 +222,6 @@ class LSTMTrainer:
         self.early_stopping = EarlyStopping(
             patience=self.params["early_stopping_rounds"],
             verbose=True,
-            delta=0.0,
         )
         self.scheduler = optim.lr_scheduler.ReduceLROnPlateau(
             self.optimizer,

--- a/src/models/lstm_model.py
+++ b/src/models/lstm_model.py
@@ -121,14 +121,15 @@ class LSTMModel(PulseTemplateModel, nn.Module):
         self.batch_norm_layers = nn.ModuleList()
 
         # Create separate dropout rates for different layers or use the same rate
-        if isinstance(self.dropout, (list, tuple)):
-            dropout_rates = self.dropout
+        if hasattr(self.dropout, "__len__"):  # Check if it's sequence-like
+            dropout_rates = list(self.dropout)
         else:
             # Create increasing dropout rates if single value provided
-            base_rate = self.dropout
+            base_rate = float(self.dropout)  # Convert to float
             dropout_rates = [
                 min(base_rate * (i + 1), 0.5) for i in range(len(self.lstm_units))
             ]
+        logger.info("Using dropout rates for LSTM layers: %s", dropout_rates)
 
         # Create the LSTM layers with respective dropout and batch norm
         input_size = self.input_size

--- a/src/models/modelmanager.py
+++ b/src/models/modelmanager.py
@@ -30,6 +30,7 @@ class ModelManager:
         if not self.models:
             logger.error("No models specified.")
             sys.exit()
+        self.benchmark_settings = config.get("benchmark_settings", {})
 
         self.wandb = config.get("wandb", {"enabled": False})
         self.output_dir = config.get("output_dir", "")
@@ -87,10 +88,16 @@ class ModelManager:
             A new model instance
         """
         model_name = config.get("name")
+
+        # Add random seed to params if not already present
+        params = config.get("params", {})
+        if "random_seed" not in params:
+            params["random_seed"] = self.benchmark_settings.get("random_seed", 42)
+
         # Create model instance from configuration
         model_cls = get_model_class(model_name)
         model = model_cls(
-            config.get("params", {}),
+            params,
             pretrained_model_path=config.get("pretrained_model_path", None),
             wandb=self.wandb.get("enabled", False),
             output_dir=self.output_dir,

--- a/src/models/randomforest_model.py
+++ b/src/models/randomforest_model.py
@@ -79,7 +79,6 @@ class RandomForestModel(PulseTemplateModel):
             "max_features",
             "bootstrap",
             "oob_score",
-            "random_state",
             "verbose",
             "criterion",
             "max_leaf_nodes",
@@ -98,6 +97,7 @@ class RandomForestModel(PulseTemplateModel):
 
         # Extract RandomForest parameters from config
         rf_params = {param: params[param] for param in required_rf_params}
+        rf_params["random_state"] = params.get("random_seed")
 
         # Log the parameters being used
         logger.info("Initializing RandomForest with parameters: %s", rf_params)

--- a/src/models/xgboost_model.py
+++ b/src/models/xgboost_model.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
-import xgboost as xgb
 from sklearn.model_selection import RandomizedSearchCV
 from xgboost import XGBClassifier
 
@@ -64,7 +63,6 @@ class XGBoostModel(PulseTemplateModel):
             "objective",
             "n_estimators",
             "learning_rate",
-            "random_state",
             "verbosity",
             "max_depth",
             "gamma",
@@ -88,12 +86,13 @@ class XGBoostModel(PulseTemplateModel):
 
         # For XGBoost 2.0.3: include early_stopping_rounds in model initialization
         model_params = {param: params[param] for param in required_xgb_params}
+        model_params["random_state"] = params.get("random_seed")
 
         # Store early_stopping_rounds for training
         self.early_stopping_rounds = params["early_stopping_rounds"]
 
         # Log the parameters being used
-        logger.info(f"Initializing XGBoost with parameters: {model_params}")
+        logger.info("Initializing XGBoost with parameters: %s", model_params)
 
         # Initialize the XGBoost model with parameters from config
         self.model = XGBClassifier(

--- a/src/models/xgboost_model.py
+++ b/src/models/xgboost_model.py
@@ -238,8 +238,9 @@ class XGBoostTrainer:
 
         results = self.model.model.evals_result()
 
-        for i in range(len(results["validation_0"]["auc"])):
-            wandb.log({"val_loss": results["validation_0"]["auc"][i], "step": i})
+        if self.wandb:
+            for i in range(len(results["validation_0"]["auc"])):
+                wandb.log({"val_loss": results["validation_0"]["auc"][i], "step": i})
 
         # Load the best model if early stopping was used
         if hasattr(self.model.model, "best_iteration"):

--- a/src/preprocessing/preprocessing_baseline/preprocessing_baseline.py
+++ b/src/preprocessing/preprocessing_baseline/preprocessing_baseline.py
@@ -584,7 +584,12 @@ class PreprocessorBaseline:
         return X_reshaped, y_reshaped
 
     def calculate_dataset_statistics(
-        self, X: pd.DataFrame, y: pd.DataFrame, set_type: str = "train"
+        self,
+        X: pd.DataFrame,
+        y: pd.DataFrame,
+        set_type: str,
+        task: str,
+        dataset_name: str,
     ) -> Dict[str, Any]:
         """
         Calculate statistics for the dataset.
@@ -593,13 +598,15 @@ class PreprocessorBaseline:
             X (pd.DataFrame): Features dataframe
             y (pd.DataFrame): Labels dataframe
             set_type (str, optional): Type of dataset ('train', 'validation', 'test'). Defaults to "train".
+            task (str): Task name (e.g., 'mortality', 'aki', 'sepsis')
+            dataset_name (str): Dataset name (e.g., 'hirid', 'miiv', 'eicu')
 
         Returns:
             Dict[str, Any]: Dictionary of dataset statistics
         """
         try:
             # For mortality task (after reshaping), use simplified statistics
-            if self.task == "mortality":
+            if task == "mortality":
                 # Count total stays (each row is now a stay)
                 total_stays = len(X)
 
@@ -609,8 +616,8 @@ class PreprocessorBaseline:
 
                 # Format the statistics in a dictionary
                 stats = {
-                    "Task": self.task,
-                    "Dataset": self.dataset_name,
+                    "Task": task,
+                    "Dataset": dataset_name,
                     "Set": set_type,
                     "Total Stays": total_stays,
                     "Cases": positive_stays,
@@ -675,8 +682,8 @@ class PreprocessorBaseline:
 
                 # Format the statistics in a dictionary for further use
                 stats = {
-                    "Task": self.task,
-                    "Dataset": self.dataset_name,
+                    "Task": task,
+                    "Dataset": dataset_name,
                     "Set": set_type,
                     "Total Stays": total_stays,
                     "Cases": positive_stays,

--- a/src/util/config_util.py
+++ b/src/util/config_util.py
@@ -1,10 +1,14 @@
 import logging
+import numpy as np
 import os
-import shutil
+import random
+import torch
+
 
 from omegaconf import OmegaConf
 
 logger = logging.getLogger("PULSE_logger")
+
 
 def load_config_with_models(base_config_path: str) -> OmegaConf:
     # Load the base YAML configuration file
@@ -27,8 +31,10 @@ def load_config_with_models(base_config_path: str) -> OmegaConf:
 
         # Add global preprocessing configuration to each model config
         if "preprocessing_advanced" in base_config:
-            model_config.params["preprocessing_advanced"] = base_config.preprocessing_advanced
-        
+            model_config.params["preprocessing_advanced"] = (
+                base_config.preprocessing_advanced
+            )
+
         # Add ALL tasks to model config - this lets the training code select the current task
         if "tasks" in base_config:
             model_config.params["tasks"] = base_config.tasks
@@ -57,6 +63,22 @@ def save_config_file(config: OmegaConf, output_dir: str) -> None:
     # Save the configuration to the output file
     OmegaConf.save(config, config_copy_path)
     logger.info("Configuration file copied to %s", config_copy_path)
+
+
+def set_seeds(seed: int) -> None:
+    """
+    Set all random seeds for reproducibility.
+
+    Args:
+        seed (int): The seed value to use
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    # For some operations in CUDA, you might also want to set:
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 # Example usage:

--- a/src/util/model_util.py
+++ b/src/util/model_util.py
@@ -279,24 +279,6 @@ def calculate_pos_weight(train_loader):
         return 1.0
 
 
-@DeprecationWarning
-def apply_model_prompt_format(model_id, prompt):
-    """
-    Apply model-specific prompt formatting.
-
-    Args:
-        model_id (str): The ID of the model.
-        prompt (str): The prompt to format.
-    """
-    # Example formatting for Llama3
-    if model_id == "Llama3Model":
-        formatted_prompt = f"<|USER|>{prompt}<|ASSISTANT|>"
-    else:
-        formatted_prompt = prompt  # No formatting needed for other models
-
-    return formatted_prompt
-
-
 def prompt_template_hf(input_text: str) -> List[Dict[str, str]]:
     """
     Create a chat-based prompt compatible with Hugging Face's apply_chat_template.
@@ -363,5 +345,7 @@ def extract_dict(output_text: str) -> Optional[Dict[str, str]]:
         output_dict = ast.literal_eval(json_text)
         return output_dict
     except (SyntaxError, ValueError) as e:
-        logger.warning(f"Failed to parse model output as dict: {e}\nRaw: {json_text}")
+        logger.warning(
+            "Failed to parse model output as dict: %s\nRaw: %s", e, json_text
+        )
         return default_json

--- a/train_models.py
+++ b/train_models.py
@@ -13,6 +13,7 @@ from src.logger_setup import init_wandb, setup_logger
 from src.models.modelmanager import ModelManager
 from src.util.config_util import load_config_with_models, save_config_file
 from src.util.slurm_util import copy_data_to_scratch, get_local_scratch_dir, is_on_slurm
+from src.util.config_util import set_seeds
 
 logger, output_dir = setup_logger()
 
@@ -32,6 +33,11 @@ class ModelTrainer:
         # Log debug mode status
         if self.config.general.debug_mode:
             logger.debug("DEBUG MODE ACTIVE: Training will use limited dataset size")
+
+        # Set random seeds for reproducibility
+        random_seed = self.config.benchmark_settings.get("random_seed", 42)
+        set_seeds(random_seed)
+        logger.info("Setting random seed to %s for reproducibility", random_seed)
 
         # -------------------- Copy data to local scratch (Slurm) --------------------
         if is_on_slurm() and self.config.general.get("use_scratch", False):

--- a/train_models.py
+++ b/train_models.py
@@ -179,19 +179,19 @@ class ModelTrainer:
                             train_dataset,
                             batch_size=batch_size,
                             shuffle=True,
-                            drop_last=True,
+                            drop_last=False,
                         )
                         val_loader = DataLoader(
                             val_dataset,
                             batch_size=batch_size,
                             shuffle=False,
-                            drop_last=True,
+                            drop_last=False,
                         )
                         test_loader = DataLoader(
                             test_dataset,
                             batch_size=batch_size,
                             shuffle=False,
-                            drop_last=True,
+                            drop_last=False,
                         )
                     else:
                         logger.error(


### PR DESCRIPTION
- ran baseline models (InceptionTime still running) -> results are now in results.json and in /nfs/nas12.ethz.ch/fs1202/green_groups_bds_public/Students/pulse_bernerja_soehlers/results_benchmark
- radar chart visualization notebook added
- convDL models now all return logits (also saved in the csv files), the metrics tracker uses sigmoid transformation for convDL models
- delete sensitivity metrics (same as recall)
- using batch size 64 and drop_last = False (because too many samples would be lost with a test set size of 100 rows for mortality)
- multiple improvements and bugfixes to the convDL model architectures
- improve memory management
- implement common random seed for all models